### PR TITLE
added ignoreCache for only writing to cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,12 +46,13 @@ Forecast.prototype.expired = function(key) {
  * Get the current weather conditions
  * @param  {Array}   location  Accepts a latitude and longitude pair as an `Array`
  * @param  {Function} callback Callback, signature: callback(err, result)
+ * @param  {Boolean} ignoreCache `true` if cache should only be written to, `false` if cache should be read from
  */
-Forecast.prototype.get = function(location, callback) {
+Forecast.prototype.get = function(location, callback, ignoreCache) {
   var self = this
     , key = crypto.createHash('md5').update(this.options + location).digest('hex');
 
-  if(this.options.cache && this.cache[key] && !this.expired(key)) {
+  if(this.options.cache && this.cache[key] && !this.expired(key) && !ignoreCache) {
     return callback(null, this.cache[key]);
   }
 
@@ -68,28 +69,4 @@ Forecast.prototype.get = function(location, callback) {
 
     return callback(null, result);
   });
-};
-
-/**
- * Get the current weather conditions without reading the cache. Overrides the cache.
- * @param  {Array}   location  Accepts a latitude and longitude pair as an `Array`
- * @param  {Function} callback Callback, signature: callback(err, result)
- */
-Forecast.prototype.getNoCache = function(location, callback) {
-    var self = this
-        , key = crypto.createHash('md5').update(this.options + location).digest('hex');
-
-    var Service = this.providers[this.options.service.toLowerCase()] || this.providers['forecast.io']
-        , service = new Service(this.options);
-
-    service.get(location, function(err, result) {
-        if(err) return callback(err);
-
-        if(self.options.cache) {
-            self.cache[key] = result;
-            self.cache[key].expires = new Date().getTime() + self.options.ttl.asMilliseconds();
-        }
-
-        return callback(null, result);
-    });
 };


### PR DESCRIPTION
I added a boolean parameter which determines whether reading from cache should be ignored. it is still always writing to cache. good for premium features with always current forecasts. does not break legacy code which does not pass the parameter.
