### PR TITLE
Add optional date support

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,14 +53,14 @@ Forecast.prototype.expired = function(key) {
 
 /**
  * Get the current weather conditions
- * @param  {Array}    location     Accepts a latitude and longitude pair as an `Array`
+ * @param  {Array}    apiParams    Accepts a latitude and longitude pair and optionally a unix timestamp as an `Array`
  * @param  {Boolean}  ignoreCache  If true then the cache will be ignored
  * @param  {Function} callback     Callback, signature: callback(err, result)
  */
-Forecast.prototype.get = function(location, ignoreCache, callback) {
+Forecast.prototype.get = function(apiParams, ignoreCache, callback) {
   var self = this;
   var key  = crypto.createHash('md5')
-    .update(this.options + location)
+    .update(this.options + apiParams)
     .digest('hex');
 
   if(typeof ignoreCache === 'function') {
@@ -78,7 +78,7 @@ Forecast.prototype.get = function(location, ignoreCache, callback) {
   var Service = this.providers[this.options.service.toLowerCase()];
   var service = new Service(this.options);
 
-  service.get(location, function(err, result) {
+  service.get(apiParams, function(err, result) {
     if(err) return callback(err);
 
     if(self.options.cache) {

--- a/providers/forecast.io/index.js
+++ b/providers/forecast.io/index.js
@@ -5,15 +5,15 @@ var ForecastIO = module.exports = function(options) {
   this.client  = new Client('https://api.forecast.io/forecast/' + this.options.key + '/');
 };
 
-ForecastIO.prototype.query = function(lat, lon, callback) {
+ForecastIO.prototype.query = function(apiParams, callback) {
   if(!this.options.key) return callback('No API key specified - Get one from https://developer.forecast.io');
 
-  var units = this.options.units.charAt(0).toLowerCase() === 'c' ? '?units=si' : '';
-  this.client.get(lat + ',' + lon + units, callback);
+      var units = this.options.units.charAt(0).toLowerCase() === 'c' ? '?units=si' : '';
+  this.client.get(apiParams.join(',') + units, callback);
 };
 
-ForecastIO.prototype.get = function(location, callback) {
-  this.query(location[0], location[1], function(err, res, body) {
+ForecastIO.prototype.get = function(apiParams, callback) {
+  this.query(apiParams, function(err, res, body) {
     if(err || !body || !body.currently) return callback(err);
     return callback(null, body);
   });


### PR DESCRIPTION
Exposes the optional DateTime parameter supported by forecast.io, found here: https://developer.forecast.io/docs/v2
