### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ Forecast.prototype.get = function(apiParams, ignoreCache, callback) {
   service.get(apiParams, function(err, result) {
     if(err) return callback(err);
 
-    if(self.options.cache) {
+    if(result !== undefined && self.options.cache) {
       self.cache[key] = result;
       self.cache[key].expires = new Date().getTime() + self.options.ttl.asMilliseconds();
     }


### PR DESCRIPTION
service.get() is delivering an undefined result object in certain cases (eg. msec timestamp given by mistake).  This causes forecast to crash.
