### PR TITLE
Object is not function fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,9 @@ Forecast.prototype.get = function(apiParams, ignoreCache, callback) {
   }
 
   var Service = this.providers[this.options.service.toLowerCase()];
+  if (Service instanceof Object) {
+    Service = Service[this.options.service.toLowerCase()];
+  }
   var service = new Service(this.options);
 
   service.get(apiParams, function(err, result) {


### PR DESCRIPTION
Inside Docker containers (and I'm sure certain versions of Node) the import for the service pulls in an object not a class. This fixes that and doesn't bother working code.