### PR TITLE
Implement DarkSky provider

### DIFF
--- a/providers/darksky.net/index.js
+++ b/providers/darksky.net/index.js
@@ -1,0 +1,20 @@
+var Client = require('request-json').JsonClient;
+
+var DarkSky = module.exports = function(options) {
+  this.options = options || {};
+  this.client  = new Client('https://api.darksky.net/forecast/' + this.options.key + '/');
+};
+
+DarkSky.prototype.query = function(apiParams, callback) {
+  if(!this.options.key) return callback('No API key specified - Get one from https://darksky.net/dev');
+
+  var units = this.options.units.charAt(0).toLowerCase() === 'c' ? '?units=si' : '';
+  this.client.get(apiParams.join(',') + units, callback);
+};
+
+DarkSky.prototype.get = function(apiParams, callback) {
+  this.query(apiParams, function(err, res, body) {
+    if(err || !body || !body.currently) return callback(err);
+    return callback(null, body);
+  });
+};

--- a/providers/index.js
+++ b/providers/index.js
@@ -1,3 +1,4 @@
 module.exports = {
-    'forecast.io': require('./forecast.io')
+    'forecast.io': require('./forecast.io'),
+    'darksky.net': require('./darksky.net')
 };


### PR DESCRIPTION
Forecast.io will soon be DarkSky.net so it might make sense to just rebrand this whole module. But as the old API will still be reachable we can leave it in place for now I guess.