### PR TITLE
Nodejs Version

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,14 +18,25 @@ var Forecast = module.exports = function (options) {
   this.providers = providers;
   this.cache = {};
 
-  this.options = Object.assign({}, {
-    service: 'darksky',
-    units: 'celcius',
-    cache: true,
-    ttl: {
+  this.options = options || {};
+
+  if (!this.options.service) {
+    this.options.service = 'darksky';
+  }
+
+  if (!this.options.units) {
+    this.options.units = 'celcius';
+  }
+
+  if (!this.options.cache) {
+    this.options.cache = true;
+  }
+
+  if (!this.options.ttl) {
+    this.options.ttl = {
       minutes: 30
     }
-  }, options || {});
+  }
 
   if (this.options.key === 'your-api-key') {
     this.options.key = null;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 0.12.0"
   },
   "devDependencies": {
     "eslint": "^3.6.1"


### PR DESCRIPTION
Object.assign only works in ES6.
This change works in ES5.

We using NodeJS in Amazon AWS Opsworks, therefore we need NodeJS 0.12.
